### PR TITLE
Fix chat history persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,9 @@
     if (!key) return;
     document.getElementById('login-screen').style.display = 'none';
     document.getElementById('chat-app').style.display = 'block';
+    getHistory().forEach(m =>
+      addMessage(m.role === 'user' ? 'Bruger' : 'Bot', m.content)
+    );
   }
   initChat();
 
@@ -71,6 +74,7 @@
     const text = promptEl.value.trim();
     if (!text) return;
     addMessage('Bruger', text);
+    saveToHistory({role:'user', content:text});
     promptEl.value = '';
     const messages = [
       { role: 'system', content:


### PR DESCRIPTION
## Summary
- fix bug preventing user messages from being saved
- load saved history when chat initializes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68836fa678f0832f8c239145291f0a58